### PR TITLE
Debug mode

### DIFF
--- a/corpus_cleaner/components/a_data_parser/fairseq_lm_parser.py
+++ b/corpus_cleaner/components/a_data_parser/fairseq_lm_parser.py
@@ -37,9 +37,9 @@ class FairseqLMParser(DataParser):
                 url = ''
                 title = ''
             else:
-                doc_lines.append(line + '\n\n')
+                doc_lines.append(line)
 
         if len(doc_lines) > 0:
             filename = relative_filepath
-            yield Document(content=''.join(doc_lines), id_=doc_id, url=url, title=title,
+            yield Document(content='\n'.join(doc_lines), id_=doc_id, url=url, title=title,
                            filename=filename)

--- a/corpus_cleaner/components/a_data_parser/fairseq_lm_parser.py
+++ b/corpus_cleaner/components/a_data_parser/fairseq_lm_parser.py
@@ -37,7 +37,7 @@ class FairseqLMParser(DataParser):
                 url = ''
                 title = ''
             else:
-                doc_lines.append(line)
+                doc_lines.append(line + '\n')
 
         if len(doc_lines) > 0:
             filename = relative_filepath

--- a/corpus_cleaner/components/a_data_parser/onion_parser.py
+++ b/corpus_cleaner/components/a_data_parser/onion_parser.py
@@ -20,7 +20,9 @@ class OnionParser(DataParser):
         doc = Document(content='')
         for line in fd:
             if not self.debug:
-                line_index, line = line.split('\t')
+                # line_index, line = line.split('\t')
+                line_index = line.split('\t')[0]
+                line = '\t'.join(line.split('\t')[1:])
             # ignore the first two lines with the start tags
             if line.startswith('<doc'):
                 sp = line.split()

--- a/corpus_cleaner/components/a_data_parser/onion_parser.py
+++ b/corpus_cleaner/components/a_data_parser/onion_parser.py
@@ -28,7 +28,7 @@ class OnionParser(DataParser):
                     doc = Document.parse_str(sp[1:-1])
                 else:
                     doc = Document(content='')
-            elif line.startswith('<p>') or line.startswith('</p>'):
+            elif line in ['<p>\n', '</p>\n']:
                 continue
             # empty the document sentences list when a new document is reached and return the document object
             elif line.startswith('</doc>'):

--- a/corpus_cleaner/components/a_data_parser/textfile_parser.py
+++ b/corpus_cleaner/components/a_data_parser/textfile_parser.py
@@ -26,5 +26,5 @@ class TextfileParser(DataParser):
         if len(doc_lines) > 0:
             doc_id = f'{relative_filepath}-{i}'
             filename = relative_filepath
-            yield Document(content=''.join(doc_lines), id_=doc_id, url=url, title=title,
+            yield Document(content='\n'.join(doc_lines), id_=doc_id, url=url, title=title,
                            filename=filename)

--- a/corpus_cleaner/components/b_encoding_fixer/encoding_fixer.py
+++ b/corpus_cleaner/components/b_encoding_fixer/encoding_fixer.py
@@ -27,7 +27,7 @@ class EncodingFixer(CleanerComponentMapper):
         document.operations = []
         document.content = ftfy.fix_text(document.content, normalization='NFKC').replace('\x92', "'")
         if document.content_orig != document.content:
-            document.operations.append('_fix_encoding')
+            document.operations.append(f'{self.__class__.__name__}-_fix_encoding')
         return document
 
     def apply(self, document: Optional[Document]) -> Optional[Document]:

--- a/corpus_cleaner/components/b_encoding_fixer/encoding_fixer.py
+++ b/corpus_cleaner/components/b_encoding_fixer/encoding_fixer.py
@@ -23,8 +23,11 @@ class EncodingFixer(CleanerComponentMapper):
         #              fix_surrogates=True, remove_control_chars=True, remove_bom=True, normalization='NFC',
         #              max_decode_length=1000000)
         # Also: Consider adding heuristics from https://github.com/PlanTL-SANIDAD/utils/tree/master/FixEncodingErrors
-
+        # TODO: initialize the attribute operations in the Document class
+        document.operations = []
         document.content = ftfy.fix_text(document.content, normalization='NFKC').replace('\x92', "'")
+        if document.content_orig != document.content:
+            document.operations.append('_fix_encoding')
         return document
 
     def apply(self, document: Optional[Document]) -> Optional[Document]:

--- a/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
+++ b/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
@@ -221,7 +221,7 @@ class PreFilterer(CleanerComponentMapper):
                 )
             self.no_eols_pattern = re.compile('\n')
             self.fasttext_lid = fasttext.load_model(os.path.join('lib', 'lid.176.bin'))
-            self.filters.append(self._filter_by_lang_doc)
+            self.filters.append(self._filter_by_lang)
         if self.dictionary_filter is not None:
             self.dictionary_filter_pattern = re.compile("|".join(self.dictionary_filter))
             self.filters.append(self._filter_by_dict)
@@ -299,7 +299,7 @@ class PreFilterer(CleanerComponentMapper):
         return True, None
 
     @debug_filter
-    def _filter_by_lang_doc(self, doc: Document):
+    def _filter_by_lang(self, doc: Document):
         content = self.url_placeholder_pattern.sub('', doc.content)
         content = self.no_eols_pattern.sub('. ', content)
         res = self.fasttext_lid.predict(content)

--- a/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
+++ b/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
@@ -320,7 +320,6 @@ class PreFilterer(CleanerComponentMapper):
     def _filter(self, document: Optional[Document]) -> Optional[Document]:
         # TODO: 1. implement replace functions that receives as input the Document
         #       2. implement a decorator for the replace functions like the decorator for filters
-        document.operations = []
         if self.language_normalization:
             document.content, subs = self._language_normalization(self.lang_filter, document.content)
             if self.debug and subs:

--- a/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
+++ b/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
@@ -254,7 +254,7 @@ class PreFilterer(CleanerComponentMapper):
             for token in ['found', '404', 'robots.txt', 'error', 'trouvée']:
                 if re.search(token, doc.heads, re.IGNORECASE):
                     value.append(token)
-                    return False, round(value, 2)
+                    return False, value
         return True, None
 
     @debug_filter

--- a/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
+++ b/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
@@ -20,7 +20,7 @@ def debug_filter(func):
             if not keep:
                 doc.operations.append(f"{func.__name__}:{value}")
                 doc.content = ''
-            return keep
+            return keep, value
         else:
             return func(self, doc)
 
@@ -353,7 +353,7 @@ class PreFilterer(CleanerComponentMapper):
 
         keep = True
         for filter_ in self.filters:
-            keep = filter_(document)
+            keep, _ = filter_(document)
             if not keep:
                 break
         if keep or self.debug:

--- a/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
+++ b/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
@@ -19,7 +19,7 @@ def debug_filter(func):
             keep = func(self, doc)
             if not keep:
                 doc.operations.append(func.__name__)
-                doc.content = 'EMPTY'
+                doc.content = ''
             return keep
         else:
             return func(self, doc)

--- a/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
+++ b/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
@@ -18,7 +18,9 @@ def debug_filter(func):
         if self.debug:
             keep, value = func(self, doc)
             if not keep:
-                doc.operations.append(f"{func.__name__}:{value}")
+                class_name = self.__class__.__name__
+                filter_name = func.__name__
+                doc.operations.append(f"{class_name}-{filter_name}:{value}")
                 doc.content = ''
             return keep, value
         else:
@@ -196,7 +198,7 @@ class PreFilterer(CleanerComponentMapper):
                 rf'\((@)?((http|https)://)?([{self.lang_chars}0-9./?\\\\@\-—_=#])+\.[a-z]{{2,6}}([{self.lang_chars}0-9&/\\\\+~*?%:!@—_=#()-])*')
             self.urls_pattern2 = re.compile('(\[URL\]\.?\w*\s*)+')
         if self.char_length_filter_document > 0:
-            self.filters.append(self._filter_by_char_len_doc)
+            self.filters.append(self._filter_by_char_len)
         if self.head_filter:
             self.filters.append(self._filter_by_heads)
         if self.digits_filter > 0:
@@ -239,7 +241,7 @@ class PreFilterer(CleanerComponentMapper):
             self.final_sentence_pattern2 = regex.compile(r"(\s)(\p{Ll}+)([.!?:]+)('|\")(\p{Lu})(\p{Ll}+)([\s.,;:?!])")
 
     @debug_filter
-    def _filter_by_char_len_doc(self, doc: Document):
+    def _filter_by_char_len(self, doc: Document):
         value = len(doc.content)
         if value < self.char_length_filter_document:
             return False, round(value, 2)
@@ -322,31 +324,31 @@ class PreFilterer(CleanerComponentMapper):
         if self.language_normalization:
             document.content, subs = self._language_normalization(self.lang_filter, document.content)
             if self.debug and subs:
-                document.operations.append(self._language_normalization.__name__)
+                document.operations.append(f"{self.__class__.__name__}-{self._language_normalization.__name__}")
         if self.replace_emails:
             document.content, subs = self._replace_emails(document.content)
             if self.debug and subs:
-                document.operations.append(self._replace_emails.__name__)
+                document.operations.append(f"{self.__class__.__name__}-{self._replace_emails.__name__}")
         if self.remove_hashtags_mentions:
             document.content, subs = self._remove_hashtags_mentions(document.content)
             if self.debug and subs:
-                document.operations.append(self._remove_hashtags_mentions.__name__)
+                document.operations.append(f"{self.__class__.__name__}-{self._remove_hashtags_mentions.__name__}")
         if self.remove_tags:
             document.content, subs = self._remove_tags(document.content)
             if self.debug and subs:
-                document.operations.append(self._remove_tags.__name__)
+                document.operations.append(f"{self.__class__.__name__}-{self._remove_tags.__name__}")
         if self.replace_urls:
             document.content, subs = self._replace_urls(document.content)
             if self.debug and subs:
-                document.operations.append(self._replace_urls.__name__)
+                document.operations.append(f"{self.__class__.__name__}-{self._replace_urls.__name__}")
         if self.space_normalization:
             document.content, subs = self._space_normalization(document.content)
             if self.debug and subs:
-                document.operations.append(self._space_normalization.__name__)
+                document.operations.append(f"{self.__class__.__name__}-{self._space_normalization.__name__}")
         if self.seg_sentences:
             document.content, subs = self._seg_sentences(document.content)
             if self.debug and subs:
-                document.operations.append(self._seg_sentences.__name__)
+                document.operations.append(f"{self.__class__.__name__}-{self._seg_sentences.__name__}")
 
         if len(document.content.split()) == 0:
             return None

--- a/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
+++ b/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
@@ -13,7 +13,7 @@ import regex
 
 # TODO: implement decorator that register the name of the operation (replace/filter) applied to each sentence
 #       That information will be used to list the operations applied to the sentences during the cleaning process
-def debug_operation(func):
+def debug_filter(func):
     def debug(self, doc):
         if self.debug:
             keep = func(self, doc)
@@ -230,13 +230,13 @@ class PreFilterer(CleanerComponentMapper):
             self.final_sentence_pattern1 = regex.compile(r"(\s)(\p{Ll}+)([.!?:]*)(\p{Lu})(\p{Ll}+)([\s.,;:?!])")
             self.final_sentence_pattern2 = regex.compile(r"(\s)(\p{Ll}+)([.!?:]+)('|\")(\p{Lu})(\p{Ll}+)([\s.,;:?!])")
 
-    @debug_operation
+    @debug_filter
     def _filter_by_length(self, doc: Document):
         if len(doc.content) < self.char_length_filter:
             return False
         return True
 
-    @debug_operation
+    @debug_filter
     def _filter_by_heads(self, doc: Document):
         if doc.heads is not None:
             for token in ['found', '404', 'robots.txt', 'error', 'trouvée']:
@@ -244,20 +244,20 @@ class PreFilterer(CleanerComponentMapper):
                     return False
         return True
 
-    @debug_operation
+    @debug_filter
     def _filter_by_digits(self, doc: Document):
         if sum(c.isdigit() for c in doc.content) / len(doc.content) > self.digits_filter:
             return False
         return True
 
-    @debug_operation
+    @debug_filter
     def _filter_by_alphanum(self, doc: Document):
         concat_content = ''.join(doc.content.split())
         if (1 - (sum(c.isalnum() for c in concat_content) / len(concat_content))) > self.alphanum_filter:
             return False
         return True
 
-    @debug_operation
+    @debug_filter
     def _filter_by_lang_chars(self, doc: Document):
         concat_content = ''.join(doc.content.split())
         if (1 - (sum(c in self.alphabet for c in concat_content) /
@@ -265,13 +265,13 @@ class PreFilterer(CleanerComponentMapper):
             return False
         return True
 
-    @debug_operation
+    @debug_filter
     def _filter_by_uppercase(self, doc: Document):
         if sum(c.isupper() for c in doc.content) / len(doc.content) > self.uppercase_filter:
             return False
         return True
 
-    @debug_operation
+    @debug_filter
     def _filter_by_alphabet(self, doc: Document):
         # TODO: Check thresholds?
         try:
@@ -281,7 +281,7 @@ class PreFilterer(CleanerComponentMapper):
             return True
         return True
 
-    @debug_operation
+    @debug_filter
     def _filter_by_lang(self, doc: Document):
         content = self.url_placeholder_pattern.sub('', doc.content)
         content = self.no_eols_pattern.sub('. ', content)
@@ -293,7 +293,7 @@ class PreFilterer(CleanerComponentMapper):
             return True
         return False
 
-    @debug_operation
+    @debug_filter
     def _filter_by_dict(self, doc: Document):
         if self.dictionary_filter_pattern.search(doc.content):
             return False
@@ -323,10 +323,6 @@ class PreFilterer(CleanerComponentMapper):
         for filter_ in self.filters:
             keep = filter_(document)
             if not keep:
-                # # if debug, keep an empty document as cleaned
-                # if self.debug:
-                #     document.content = ''
-                #     # document.operations.append(filter_.__name__)
                 break
         if keep or self.debug:
             return document

--- a/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
+++ b/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
@@ -11,6 +11,22 @@ from corpus_cleaner.configs.langs import langs
 import regex
 
 
+# TODO: implement decorator that register the name of the operation (replace/filter) applied to each sentence
+#       That information will be used to list the operations applied to the sentences during the cleaning process
+def debug_operation(func):
+    def debug(self, doc):
+        if self.debug:
+            keep = func(self, doc)
+            if not keep:
+                doc.operations.append(func.__name__)
+                doc.content = ''
+            return keep
+        else:
+            return func(self, doc)
+
+    return debug
+
+
 class PreFilterer(CleanerComponentMapper):
 
     @staticmethod
@@ -109,11 +125,6 @@ class PreFilterer(CleanerComponentMapper):
         self.input_format = args.input_format
         self.filters = []
         self._build_filters()
-
-    # TODO: implement decorator that register the name of the operation (replace/filter) applied to each sentence
-    #       That information will be used to list the operations applied to the sentences during the cleaning process
-    def register_applied_operations(self):
-        pass
 
     # TODO: move the remove operations to a new component called CharFilter
     def _language_normalization(self, langs, text):
@@ -219,30 +230,34 @@ class PreFilterer(CleanerComponentMapper):
             self.final_sentence_pattern1 = regex.compile(r"(\s)(\p{Ll}+)([.!?:]*)(\p{Lu})(\p{Ll}+)([\s.,;:?!])")
             self.final_sentence_pattern2 = regex.compile(r"(\s)(\p{Ll}+)([.!?:]+)('|\")(\p{Lu})(\p{Ll}+)([\s.,;:?!])")
 
+    @debug_operation
     def _filter_by_length(self, doc: Document):
         if len(doc.content) < self.char_length_filter:
             return False
         return True
 
-    @staticmethod
-    def _filter_by_heads(doc: Document):
+    @debug_operation
+    def _filter_by_heads(self, doc: Document):
         if doc.heads is not None:
             for token in ['found', '404', 'robots.txt', 'error', 'trouvée']:
                 if re.search(token, doc.heads, re.IGNORECASE):
                     return False
         return True
 
+    @debug_operation
     def _filter_by_digits(self, doc: Document):
         if sum(c.isdigit() for c in doc.content) / len(doc.content) > self.digits_filter:
             return False
         return True
 
+    @debug_operation
     def _filter_by_alphanum(self, doc: Document):
         concat_content = ''.join(doc.content.split())
         if (1 - (sum(c.isalnum() for c in concat_content) / len(concat_content))) > self.alphanum_filter:
             return False
         return True
 
+    @debug_operation
     def _filter_by_lang_chars(self, doc: Document):
         concat_content = ''.join(doc.content.split())
         if (1 - (sum(c in self.alphabet for c in concat_content) /
@@ -250,11 +265,13 @@ class PreFilterer(CleanerComponentMapper):
             return False
         return True
 
+    @debug_operation
     def _filter_by_uppercase(self, doc: Document):
         if sum(c.isupper() for c in doc.content) / len(doc.content) > self.uppercase_filter:
             return False
         return True
 
+    @debug_operation
     def _filter_by_alphabet(self, doc: Document):
         # TODO: Check thresholds?
         try:
@@ -264,6 +281,7 @@ class PreFilterer(CleanerComponentMapper):
             return True
         return True
 
+    @debug_operation
     def _filter_by_lang(self, doc: Document):
         content = self.url_placeholder_pattern.sub('', doc.content)
         content = self.no_eols_pattern.sub('. ', content)
@@ -275,12 +293,14 @@ class PreFilterer(CleanerComponentMapper):
             return True
         return False
 
+    @debug_operation
     def _filter_by_dict(self, doc: Document):
         if self.dictionary_filter_pattern.search(doc.content):
             return False
         return True
 
     def _filter(self, document: Optional[Document]) -> Optional[Document]:
+        document.operations = []
         if self.language_normalization:
             document.content = self._language_normalization(self.lang_filter, document.content)
         if self.replace_emails:
@@ -303,9 +323,10 @@ class PreFilterer(CleanerComponentMapper):
         for filter_ in self.filters:
             keep = filter_(document)
             if not keep:
-                # if debug, keep an empty document as cleaned
-                if self.debug:
-                    document.content = ''
+                # # if debug, keep an empty document as cleaned
+                # if self.debug:
+                #     document.content = ''
+                #     # document.operations.append(filter_.__name__)
                 break
         if keep or self.debug:
             return document

--- a/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
+++ b/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
@@ -162,16 +162,16 @@ class PreFilterer(CleanerComponentMapper):
         subs_all.append(subs)
         return text, any(subs_all)
 
-    def fix(self, text):
-        text = normalize_space(text, preserve=['\n'])
-        text = self.punc_space_pattern.sub('\\2', text)
-        text = self.zero_width_space_pattern.sub('', text)
-        text = self.punc_no_space_pattern.sub('\\1\\2 \\3', text)
-        text = self.quote_no_space_pattern1.sub('\\1 \\2\\3\\5', text)
-        text = self.quote_no_space_pattern2.sub('\\1\\2\\4 \\5', text)
-        text = self.final_sentence_pattern1.subf("{1}{2}{3}\n{4}{5}{6}", text)
-        text = self.final_sentence_pattern2.subf("{1}{2}{3}\n{4}{5}{6}{7}", text)
-        return text
+    # def fix(self, text):
+    #     text = normalize_space(text, preserve=['\n'])
+    #     text = self.punc_space_pattern.sub('\\2', text)
+    #     text = self.zero_width_space_pattern.sub('', text)
+    #     text = self.punc_no_space_pattern.sub('\\1\\2 \\3', text)
+    #     text = self.quote_no_space_pattern1.sub('\\1 \\2\\3\\5', text)
+    #     text = self.quote_no_space_pattern2.sub('\\1\\2\\4 \\5', text)
+    #     text = self.final_sentence_pattern1.subf("{1}{2}{3}\n{4}{5}{6}", text)
+    #     text = self.final_sentence_pattern2.subf("{1}{2}{3}\n{4}{5}{6}{7}", text)
+    #     return text
 
     def _seg_sentences(self, text):
         subs_all = []

--- a/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
+++ b/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
@@ -18,7 +18,7 @@ def debug_filter(func):
         if self.debug:
             keep = func(self, doc)
             if not keep:
-                doc.doc_ops.append(func.__name__)
+                doc.operations.append(func.__name__)
                 doc.content = 'EMPTY'
             return keep
         else:
@@ -321,35 +321,35 @@ class PreFilterer(CleanerComponentMapper):
     def _filter(self, document: Optional[Document]) -> Optional[Document]:
         # TODO: 1. implement replace functions that receives as input the Document
         #       2. implement a decorator for the replace functions like the decorator for filters
-        document.doc_ops = []
+        document.operations = []
         if self.language_normalization:
             document.content, subs = self._language_normalization(self.lang_filter, document.content)
             if self.debug and subs:
-                document.doc_ops.append(self._language_normalization.__name__)
+                document.operations.append(self._language_normalization.__name__)
         if self.replace_emails:
             document.content, subs = self._replace_emails(document.content)
             if self.debug and subs:
-                document.doc_ops.append(self._replace_emails.__name__)
+                document.operations.append(self._replace_emails.__name__)
         if self.remove_hashtags_mentions:
             document.content, subs = self._remove_hashtags_mentions(document.content)
             if self.debug and subs:
-                document.doc_ops.append(self._remove_hashtags_mentions.__name__)
+                document.operations.append(self._remove_hashtags_mentions.__name__)
         if self.remove_tags:
             document.content, subs = self._remove_tags(document.content)
             if self.debug and subs:
-                document.doc_ops.append(self._remove_tags.__name__)
+                document.operations.append(self._remove_tags.__name__)
         if self.replace_urls:
             document.content, subs = self._replace_urls(document.content)
             if self.debug and subs:
-                document.doc_ops.append(self._replace_urls.__name__)
+                document.operations.append(self._replace_urls.__name__)
         if self.space_normalization:
             document.content, subs = self._space_normalization(document.content)
             if self.debug and subs:
-                document.doc_ops.append(self._space_normalization.__name__)
+                document.operations.append(self._space_normalization.__name__)
         if self.seg_sentences:
             document.content, subs = self._seg_sentences(document.content)
             if self.debug and subs:
-                document.doc_ops.append(self._seg_sentences.__name__)
+                document.operations.append(self._seg_sentences.__name__)
 
         if len(document.content.split()) == 0:
             return None

--- a/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
+++ b/corpus_cleaner/components/c_pre_filterer/pre_filterer.py
@@ -242,7 +242,7 @@ class PreFilterer(CleanerComponentMapper):
     def _filter_by_length(self, doc: Document):
         value = len(doc.content)
         if value < self.char_length_filter:
-            return False, value
+            return False, round(value, 2)
         return True, None
 
     @debug_filter
@@ -252,14 +252,14 @@ class PreFilterer(CleanerComponentMapper):
             for token in ['found', '404', 'robots.txt', 'error', 'trouvée']:
                 if re.search(token, doc.heads, re.IGNORECASE):
                     value.append(token)
-                    return False, value
+                    return False, round(value, 2)
         return True, None
 
     @debug_filter
     def _filter_by_digits(self, doc: Document):
         value = sum(c.isdigit() for c in doc.content) / len(doc.content)
         if value > self.digits_filter:
-            return False, value
+            return False, round(value, 2)
         return True, None
 
     @debug_filter
@@ -267,7 +267,7 @@ class PreFilterer(CleanerComponentMapper):
         concat_content = ''.join(doc.content.split())
         value = (1 - (sum(c.isalnum() for c in concat_content) / len(concat_content)))
         if value > self.alphanum_filter:
-            return False, value
+            return False, round(value, 2)
         return True, None
 
     @debug_filter
@@ -275,14 +275,14 @@ class PreFilterer(CleanerComponentMapper):
         concat_content = ''.join(doc.content.split())
         value = (1 - (sum(c in self.alphabet for c in concat_content) / len(concat_content)))
         if value > self.lang_chars_filter:
-            return False, value
+            return False, round(value, 2)
         return True, None
 
     @debug_filter
     def _filter_by_uppercase(self, doc: Document):
         value = sum(c.isupper() for c in doc.content) / len(doc.content)
         if value > self.uppercase_filter:
-            return False, value
+            return False, round(value, 2)
         return True, None
 
     @debug_filter
@@ -306,7 +306,7 @@ class PreFilterer(CleanerComponentMapper):
         if lang in self.lang_filter and conf > self.initial_lang_filter_threshold:
             doc.language = lang
             return True, None
-        value = f"({conf}, {lang})"
+        value = f"({round(conf, 2)}, {lang})"
         return False, value
 
     @debug_filter

--- a/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
+++ b/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
@@ -46,19 +46,20 @@ class SentenceSplitterComponent(CleanerComponentMapper):
             # but the debug mode is activated, store a number of empty cleaned sentences equal to
             # the number of lines in the original content
             empty_sentences_number = len(document.content_orig.splitlines())
-            document.sentences = ['EMPTY'] * empty_sentences_number
+            document.sentences = [''] * empty_sentences_number
             document.sentences_orig = [document.content_orig]
         else:
             document.sentences = [sent for sent in splitter.split(document.content)]
             document.sentences_orig = [sent for sent in splitter.split(document.content_orig)]
             if len(document.sentences) > 1:
-                document.content_ops.append("_sentence_splitter")
+                document.operations.append("_sentence_splitter")
 
-            # add operations for each sentence in the document
-            document.operations = [document.operations] * len(document.sentences)
             # Return None the original sentences are not aligned to the cleaned sentences
             if not len(document.sentences) == len(document.sentences_orig):
                 return None
+
+        # add operations for each sentence in the document
+        document.operations = [document.operations] * len(document.sentences)
         return document
 
     def apply(self, document: Optional[Document]) -> Optional[Document]:

--- a/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
+++ b/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
@@ -52,9 +52,6 @@ class SentenceSplitterComponent(CleanerComponentMapper):
             else:
                 document.sentences = [sent for sent in splitter.split(document.content)]
                 document.sentences_orig = [sent for sent in splitter.split(document.content_orig)]
-                if len(document.sentences) > 1 and self.debug:
-                    # TODO: add the name of the operations from the function's name
-                    document.operations.append("_sentence_splitter")
 
                 # Return None the original sentences are not aligned to the cleaned sentences
                 if not len(document.sentences) == len(document.sentences_orig):

--- a/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
+++ b/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
@@ -53,6 +53,9 @@ class SentenceSplitterComponent(CleanerComponentMapper):
                 document.sentences = [sent for sent in splitter.split(document.content)]
                 document.sentences_orig = [sent for sent in splitter.split(document.content_orig)]
 
+                if len(document.sentences) > 1:
+                    document.operations.append(f'{self.__class__.__name__}-_sentence_splitter')
+
                 # If the original sentences are not aligned to the cleaned ones, place the whole document on the first
                 # line to allow manual alignment
                 if not len(document.sentences) == len(document.sentences_orig):

--- a/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
+++ b/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
@@ -57,7 +57,10 @@ class SentenceSplitterComponent(CleanerComponentMapper):
                     document.operations.append("_sentence_splitter")
 
                 # Return None the original sentences are not aligned to the cleaned sentences
-                if not len(document.sentences) == len(document.sentences_orig):
+                if not len(document.sentences) > len(document.sentences_orig):
+                    document.sentences_orig = [document.content_orig]
+                    document.sentences_orig.extend([''] * (len(document.sentences) - len(document.sentences_orig)))
+                elif len(document.sentences) < len(document.sentences_orig):
                     return None
 
             # add operations for each sentence in the document

--- a/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
+++ b/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
@@ -57,15 +57,12 @@ class SentenceSplitterComponent(CleanerComponentMapper):
                     document.operations.append("_sentence_splitter")
 
                 # Return None the original sentences are not aligned to the cleaned sentences
-                if not len(document.sentences) > len(document.sentences_orig):
-                    document.sentences_orig = [document.content_orig]
-                    document.sentences_orig.extend([''] * (len(document.sentences) - len(document.sentences_orig)))
-                elif len(document.sentences) < len(document.sentences_orig):
+                if not len(document.sentences) == len(document.sentences_orig):
                     return None
 
             # add operations for each sentence in the document
             # TODO: assign the operations to document and sentences separately
-            document.operations = [document.operations] * len(document.sentences)
+            document.operations = [document.operations.copy() for _ in range(len(document.sentences))]
         return document
 
     def apply(self, document: Optional[Document]) -> Optional[Document]:

--- a/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
+++ b/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
@@ -52,6 +52,7 @@ class SentenceSplitterComponent(CleanerComponentMapper):
             document.sentences = [sent for sent in splitter.split(document.content)]
             document.sentences_orig = [sent for sent in splitter.split(document.content_orig)]
             if len(document.sentences) > 1:
+                # TODO: add the name of the operations from the function's name
                 document.operations.append("_sentence_splitter")
 
             # Return None the original sentences are not aligned to the cleaned sentences

--- a/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
+++ b/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
@@ -51,7 +51,7 @@ class SentenceSplitterComponent(CleanerComponentMapper):
         else:
             document.sentences = [sent for sent in splitter.split(document.content)]
             document.sentences_orig = [sent for sent in splitter.split(document.content_orig)]
-            if len(document.sentences) > 1:
+            if len(document.sentences) > 1 and self.debug:
                 # TODO: add the name of the operations from the function's name
                 document.operations.append("_sentence_splitter")
 
@@ -60,6 +60,7 @@ class SentenceSplitterComponent(CleanerComponentMapper):
                 return None
 
         # add operations for each sentence in the document
+        # TODO: assign the operations to document and sentences separately
         document.operations = [document.operations] * len(document.sentences)
         return document
 

--- a/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
+++ b/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
@@ -41,27 +41,28 @@ class SentenceSplitterComponent(CleanerComponentMapper):
             self.splitter_dict[document.language] = sentence_splitter.SentenceSplitter(language=document.language)
             splitter = self.splitter_dict[document.language]
 
-        if not document.content and self.debug:
-            # If the document received is empty since has been filtered out in the previous step,
-            # but the debug mode is activated, store a number of empty cleaned sentences equal to
-            # the number of lines in the original content
-            empty_sentences_number = len(document.content_orig.splitlines())
-            document.sentences = [''] * empty_sentences_number
-            document.sentences_orig = [document.content_orig]
-        else:
-            document.sentences = [sent for sent in splitter.split(document.content)]
-            document.sentences_orig = [sent for sent in splitter.split(document.content_orig)]
-            if len(document.sentences) > 1 and self.debug:
-                # TODO: add the name of the operations from the function's name
-                document.operations.append("_sentence_splitter")
+        if self.debug:
+            if not document.content:
+                # If the document received is empty since has been filtered out in the previous step,
+                # but the debug mode is activated, store a number of empty cleaned sentences equal to
+                # the number of lines in the original content
+                empty_sentences_number = len(document.content_orig.splitlines())
+                document.sentences = [''] * empty_sentences_number
+                document.sentences_orig = [document.content_orig]
+            else:
+                document.sentences = [sent for sent in splitter.split(document.content)]
+                document.sentences_orig = [sent for sent in splitter.split(document.content_orig)]
+                if len(document.sentences) > 1 and self.debug:
+                    # TODO: add the name of the operations from the function's name
+                    document.operations.append("_sentence_splitter")
 
-            # Return None the original sentences are not aligned to the cleaned sentences
-            if not len(document.sentences) == len(document.sentences_orig):
-                return None
+                # Return None the original sentences are not aligned to the cleaned sentences
+                if not len(document.sentences) == len(document.sentences_orig):
+                    return None
 
-        # add operations for each sentence in the document
-        # TODO: assign the operations to document and sentences separately
-        document.operations = [document.operations] * len(document.sentences)
+            # add operations for each sentence in the document
+            # TODO: assign the operations to document and sentences separately
+            document.operations = [document.operations] * len(document.sentences)
         return document
 
     def apply(self, document: Optional[Document]) -> Optional[Document]:

--- a/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
+++ b/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
@@ -48,7 +48,7 @@ class SentenceSplitterComponent(CleanerComponentMapper):
                 # the number of lines in the original content
                 empty_sentences_number = len(document.content_orig.splitlines())
                 document.sentences = [''] * empty_sentences_number
-                document.sentences_orig = [document.content_orig]
+                document.sentences_orig = document.content_orig.splitlines()
             else:
                 document.sentences = [sent for sent in splitter.split(document.content)]
                 document.sentences_orig = [sent for sent in splitter.split(document.content_orig)]
@@ -60,6 +60,8 @@ class SentenceSplitterComponent(CleanerComponentMapper):
             # add operations for each sentence in the document
             # TODO: assign the operations to document and sentences separately
             document.operations = [document.operations.copy() for _ in range(len(document.sentences))]
+        else:
+            document.sentences = [sent for sent in splitter.split(document.content)]
         return document
 
     def apply(self, document: Optional[Document]) -> Optional[Document]:

--- a/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
+++ b/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
@@ -53,12 +53,15 @@ class SentenceSplitterComponent(CleanerComponentMapper):
                 document.sentences = [sent for sent in splitter.split(document.content)]
                 document.sentences_orig = [sent for sent in splitter.split(document.content_orig)]
 
-                # Return None the original sentences are not aligned to the cleaned sentences
+                # If the original sentences are not aligned to the cleaned ones, place the whole document on the first
+                # line to allow manual alignment
                 if not len(document.sentences) == len(document.sentences_orig):
-                    return None
+                    if len(document.sentences) > len(document.sentences_orig):
+                        content_orig = document.content_orig.replace('\n', '')
+                        document.sentences_orig = [f'UNALIGNED:{content_orig}']
+                        document.sentences_orig.extend(['UNALIGNED:'] * (len(document.sentences) - len(document.sentences_orig)))
 
             # add operations for each sentence in the document
-            # TODO: assign the operations to document and sentences separately
             document.operations = [document.operations.copy() for _ in range(len(document.sentences))]
         else:
             document.sentences = [sent for sent in splitter.split(document.content)]

--- a/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
+++ b/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
@@ -46,7 +46,7 @@ class SentenceSplitterComponent(CleanerComponentMapper):
             # but the debug mode is activated, store a number of empty cleaned sentences equal to
             # the number of lines in the original content
             empty_sentences_number = len(document.content_orig.splitlines())
-            document.sentences = [''] * empty_sentences_number
+            document.sentences = ['EMPTY'] * empty_sentences_number
             document.sentences_orig = [document.content_orig]
         else:
             document.sentences = [sent for sent in splitter.split(document.content)]

--- a/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
+++ b/corpus_cleaner/components/d_sentence_splitter_component/sentence_splitter_component.py
@@ -51,6 +51,11 @@ class SentenceSplitterComponent(CleanerComponentMapper):
         else:
             document.sentences = [sent for sent in splitter.split(document.content)]
             document.sentences_orig = [sent for sent in splitter.split(document.content_orig)]
+            if len(document.sentences) > 1:
+                document.content_ops.append("_sentence_splitter")
+
+            # add operations for each sentence in the document
+            document.operations = [document.operations] * len(document.sentences)
             # Return None the original sentences are not aligned to the cleaned sentences
             if not len(document.sentences) == len(document.sentences_orig):
                 return None

--- a/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
+++ b/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
@@ -124,13 +124,14 @@ class SentenceFilter(CleanerComponentMapper):
         # For each document, get the set of duplicate sentences to remove
         self.sentences_duplicate = set(sentence for sentence in document.sentences
                                        if document.sentences.count(sentence) > 1)
-        for sentence in document.sentences:
+        for sentence_idx, sentence in enumerate(document.sentences):
             keep = True
             for filter_ in self.filters:
                 keep = filter_(sentence)
                 if not keep:
                     # if debug, keep an empty sentence as cleaned
                     if self.debug:
+                        document.operations[sentence_idx].append(filter_.__name__)
                         sentences.append('EMPTY')
                     break
             if keep:

--- a/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
+++ b/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
@@ -131,8 +131,10 @@ class SentenceFilter(CleanerComponentMapper):
                 if not keep:
                     # if debug, keep an empty sentence as cleaned
                     if self.debug:
-                        document.operations[sentence_idx].append(filter_.__name__)
-                        sentences.append('EMPTY')
+                        # register operation only if the sentence is not empty
+                        if sentence:
+                            document.operations[sentence_idx].append(filter_.__name__)
+                        sentences.append('')
                     break
             if keep:
                 sentences.append(sentence)

--- a/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
+++ b/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
@@ -82,14 +82,14 @@ class SentenceFilter(CleanerComponentMapper):
             self.fasttext_lid = fasttext.load_model(os.path.join('lib', 'lid.176.bin'))
             self.lang_id = LanguageIdentifier.from_modelstring(model, norm_probs=True)
             _ = self.lang_id.classify('')  # force init
-            self.filters.append(self.__filter_by_lang)
+            self.filters.append(self._filter_by_lang)
         if self.dictionary_filter is not None:
             self.dictionary_filter_pattern = re.compile("|".join(self.dictionary_filter))
             self.filters.append(self._filter_by_dict)
         if self.dedup_same_doc_sentences:
             self.filters.append(self._filter_by_duplicate)
 
-    def filter_by_len(self, sentence: str):
+    def _filter_by_len(self, sentence: str):
         len_sentence = len(sentence)
         len_words = len(sentence.split(' '))
         if len_sentence > self.char_length_filter_sentence and len_words > self.word_length_filter_sentence:
@@ -104,7 +104,7 @@ class SentenceFilter(CleanerComponentMapper):
             return False, round(value, 2)
         return True, None
 
-    def __filter_by_lang(self, sentence: str):
+    def _filter_by_lang(self, sentence: str):
         res = self.fasttext_lid.predict(sentence.lower())
         lang = res[0][0][-2:]
         conf = res[1][0]

--- a/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
+++ b/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
@@ -109,6 +109,9 @@ class SentenceFilter(CleanerComponentMapper):
             conf = res[1]
             if lang in self.lang_filter and conf > self.slow_lang_filter_threshold:
                 return True, None
+            else:
+                value = f"({round(conf, 2)}, {lang})"
+                return False, value
         value = f"({round(conf, 2)}, {lang})"
         return False, value
 

--- a/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
+++ b/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
@@ -75,7 +75,7 @@ class SentenceFilter(CleanerComponentMapper):
 
     def _get_filters(self):
         if self.char_length_filter_sentence is not None:
-            self.filters.append(self.filter_by_len)
+            self.filters.append(self._filter_by_len)
         if self.code_threshold != -1:
             self.filters.append(self._filter_by_code)
         if self.lang_filter is not None:

--- a/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
+++ b/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
@@ -88,14 +88,14 @@ class SentenceFilter(CleanerComponentMapper):
         value = len(sentence)
         if value > self.char_length_filter_sentence:
             return True, None
-        return False, value
+        return False, round(value, 2)
 
     def _filter_by_code(self, sentence: str):
         value = (len(re.findall(self.code_keywords_pattern, sentence)) / len(sentence.split())) \
                 + len(re.findall(self.code_chars_pattern, sentence)) / len(sentence)
         if value > self.code_threshold:
-            return False, value
-        return True, value
+            return False, round(value, 2)
+        return True, None
 
     def _filter_by_lang_sent(self, sentence: str):
         res = self.fasttext_lid.predict(sentence.lower())
@@ -109,7 +109,7 @@ class SentenceFilter(CleanerComponentMapper):
             conf = res[1]
             if lang in self.lang_filter and conf > self.slow_lang_filter_threshold:
                 return True, None
-        value = f"({conf}, {lang})"
+        value = f"({round(conf, 2)}, {lang})"
         return False, value
 
     def _filter_by_dict(self, sentence: str):

--- a/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
+++ b/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
@@ -13,6 +13,8 @@ class SentenceFilter(CleanerComponentMapper):
     def add_args(parser: argparse.ArgumentParser):
         parser.add_argument('--char-length-filter-sentence', type=int, default=30,
                             help='filter sentences shorter than a given minimum character length')
+        parser.add_argument('--word-length-filter-sentence', type=int, default=2,
+                            help='filter sentences shorter than a given minimum word length')
         parser.add_argument('--profanity-check', action='store_true',
                             help='filter sentences with sensible content')
         parser.add_argument('--fast-lang-filter-threshold', type=float, help='If --lang-filter is set, minimum'
@@ -37,6 +39,7 @@ class SentenceFilter(CleanerComponentMapper):
         pass
 
     def __init__(self, args: argparse.Namespace, char_length_filter_sentence: int = 30,
+                 word_length_filter_sentence: int = 2,
                  lang_filter: Union[Tuple[str], None] = None, slow_lang_filter_threshold: float = 0.90,
                  code_threshold: float = 0.25,
                  profanity_check: bool = False, dictionary_filter: Optional[str] = None,
@@ -45,6 +48,8 @@ class SentenceFilter(CleanerComponentMapper):
         super().__init__(args)
         self.char_length_filter_sentence = args.char_length_filter_sentence if args.char_length_filter_sentence is not \
                                                                                None else char_length_filter_sentence
+        self.word_length_filter_sentence = args.word_length_filter_sentence if args.word_length_filter_sentence is not \
+                                                                               None else word_length_filter_sentence
         self.profanity_check = args.profanity_check if args.profanity_check is not None else profanity_check
         self.lang_filter = args.lang_filter if args.lang_filter is not None else lang_filter
         self.lang_id = None
@@ -70,7 +75,7 @@ class SentenceFilter(CleanerComponentMapper):
 
     def _get_filters(self):
         if self.char_length_filter_sentence is not None:
-            self.filters.append(self._filter_by_char_len)
+            self.filters.append(self._filter_by_len_sent)
         if self.code_threshold != -1:
             self.filters.append(self._filter_by_code)
         if self.lang_filter is not None:
@@ -84,11 +89,13 @@ class SentenceFilter(CleanerComponentMapper):
         if self.dedup_same_doc_sentences:
             self.filters.append(self._filter_by_duplicate)
 
-    def _filter_by_char_len(self, sentence: str):
-        value = len(sentence)
-        if value > self.char_length_filter_sentence:
+    def _filter_by_len_sent(self, sentence: str):
+        len_sentence = len(sentence)
+        len_words = len(sentence.split(' '))
+        if len_sentence > self.char_length_filter_sentence and len_words > self.word_length_filter_sentence:
             return True, None
-        return False, round(value, 2)
+        value = f"({round(len_sentence)} chars, {len_words} words)"
+        return False, value
 
     def _filter_by_code(self, sentence: str):
         value = (len(re.findall(self.code_keywords_pattern, sentence)) / len(sentence.split())) \

--- a/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
+++ b/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
@@ -131,7 +131,7 @@ class SentenceFilter(CleanerComponentMapper):
                 if not keep:
                     # if debug, keep an empty sentence as cleaned
                     if self.debug:
-                        sentences.append('')
+                        sentences.append('EMPTY')
                     break
             if keep:
                 sentences.append(sentence)

--- a/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
+++ b/corpus_cleaner/components/e_sentence_filter/sentence_filter.py
@@ -113,12 +113,12 @@ class SentenceFilter(CleanerComponentMapper):
             return False
         return True
 
-    # TODO: check if this new implementation work properly
     def _filter_by_duplicate(self, sentence: str) -> bool:
         if sentence in self.sentences_duplicate:
             return False
         return True
 
+    # TODO: add decorators to register the filters
     def _filter(self, document: Optional[Document]) -> Optional[Document]:
         sentences = []
         # For each document, get the set of duplicate sentences to remove

--- a/corpus_cleaner/components/f_normalizer/normalizer.py
+++ b/corpus_cleaner/components/f_normalizer/normalizer.py
@@ -37,7 +37,8 @@ class Normalizer(CleanerComponentMapper):
                 sent_norm = normalizer(sent_norm)
                 if self.debug and sent_norm:
                     if sent_norm != sent:
-                        document.operations[idx_sent].append(normalizer.__name__)
+                        class_name = self.__class__.__name__
+                        document.operations[idx_sent].append(f"{class_name}-{normalizer.__name__}")
             sent_norms.append(sent_norm)
         document.sentences = sent_norms
         return document

--- a/corpus_cleaner/components/f_normalizer/normalizer.py
+++ b/corpus_cleaner/components/f_normalizer/normalizer.py
@@ -31,17 +31,20 @@ class Normalizer(CleanerComponentMapper):
 
     def _normalize(self, document: Optional[Document]) -> Optional[Document]:
         sent_norms = []
-        for sent in document.sentences:
+        for idx_sent, sent in enumerate(document.sentences):
             sent_norm = sent
             for normalizer in self.normalizers:
-                sent_norm = normalizer.normalize(sent_norm)
+                sent_norm = normalizer(sent_norm)
+                if self.debug and sent_norm:
+                    if sent_norm != sent:
+                        document.operations[idx_sent].append(normalizer.__name__)
             sent_norms.append(sent_norm)
         document.sentences = sent_norms
         return document
 
     def _build_normalizers(self):
         if self.punctuation_norm:
-            self.normalizers.append(self._punctuation_normalization())
+            self.normalizers.append(self._punctuation_normalization)
         if self.spell_check:
             raise NotImplementedError()
         if self.terminology_norm is not None:
@@ -53,8 +56,8 @@ class Normalizer(CleanerComponentMapper):
     def _terminology_normalization(self):
         raise NotImplementedError()
 
-    def _punctuation_normalization(self):
-        return MosesPunctNormalizer(self.language[0])
+    def _punctuation_normalization(self, sentence: str):
+        return MosesPunctNormalizer(self.language[0]).normalize(sentence)
 
     def apply(self, document: Optional[Document]) -> Optional[Document]:
         return self._normalize(document)

--- a/corpus_cleaner/components/i_output_formatter/fairseq_lm_output_formatter.py
+++ b/corpus_cleaner/components/i_output_formatter/fairseq_lm_output_formatter.py
@@ -10,8 +10,8 @@ class FairseqLMOutputFormatter(OutputFormatter):
 
     def _write_document(self, document: Document):
         if len(document.sentences) > 0:
-            sentences = [sentence.replace(f'{self.separator}', '\t') for sentence in document.sentences]
-            self.fd.writelines(f'{sentence}\n' for sentence in sentences)
+            # sentences = [sentence.replace(f'{self.separator}', '\t') for sentence in document.sentences]
+            self.fd.writelines(f'{sentence}\n' for sentence in document.sentences)
             self.fd.write('\n')
 
     def _end_writing(self):

--- a/corpus_cleaner/components/i_output_formatter/fairseq_lm_output_formatter.py
+++ b/corpus_cleaner/components/i_output_formatter/fairseq_lm_output_formatter.py
@@ -10,7 +10,8 @@ class FairseqLMOutputFormatter(OutputFormatter):
 
     def _write_document(self, document: Document):
         if len(document.sentences) > 0:
-            self.fd.writelines(f'{sentence}\n' for sentence in document.sentences)
+            sentences = [sentence.replace(f'{self.separator}', '\t') for sentence in document.sentences]
+            self.fd.writelines(f'{sentence}\n' for sentence in sentences)
             self.fd.write('\n')
 
     def _end_writing(self):

--- a/corpus_cleaner/components/i_output_formatter/onion_output_formatter.py
+++ b/corpus_cleaner/components/i_output_formatter/onion_output_formatter.py
@@ -2,8 +2,6 @@ from .output_formatter import OutputFormatter
 from corpus_cleaner.document import Document
 import argparse
 
-SEPARATOR = " ||| "
-
 
 class OnionOutputFormatter(OutputFormatter):
     def __init__(self, args: argparse.Namespace, output_path: str, **kwargs):
@@ -12,7 +10,6 @@ class OnionOutputFormatter(OutputFormatter):
         self.start_p_tag = ' >\n<p>\n'
         self.end_doc_tag = '\n</p>\n</doc>\n'
         self.debug = args.debug
-        self.separator = SEPARATOR
 
     def _init_writing(self):
         self.fd = open(self.path, 'a')

--- a/corpus_cleaner/components/i_output_formatter/onion_output_formatter.py
+++ b/corpus_cleaner/components/i_output_formatter/onion_output_formatter.py
@@ -2,7 +2,7 @@ from .output_formatter import OutputFormatter
 from corpus_cleaner.document import Document
 import argparse
 
-SEPARATOR = "|||"
+SEPARATOR = " ||| "
 
 
 class OnionOutputFormatter(OutputFormatter):

--- a/corpus_cleaner/components/i_output_formatter/onion_output_formatter.py
+++ b/corpus_cleaner/components/i_output_formatter/onion_output_formatter.py
@@ -20,8 +20,7 @@ class OnionOutputFormatter(OutputFormatter):
     def _write_document(self, document: Document):
         if document is not None:
             if self.debug:
-                # TODO: extract the operarions for each sentence in the document
-                operations = [", ".join(document.doc_ops)]
+                operations = [", ".join(ops) for ops in document.operations]
                 sentences = [f'{sent_orig}{self.separator}{sent_clean}{self.separator}{operation}'
                              for sent_orig, sent_clean, operation in zip(document.sentences_orig,
                                                                          document.sentences,

--- a/corpus_cleaner/components/i_output_formatter/onion_output_formatter.py
+++ b/corpus_cleaner/components/i_output_formatter/onion_output_formatter.py
@@ -20,8 +20,12 @@ class OnionOutputFormatter(OutputFormatter):
     def _write_document(self, document: Document):
         if document is not None:
             if self.debug:
-                sentences = [f'{sent_orig}{self.separator}{sent_clean}'
-                             for sent_orig, sent_clean in zip(document.sentences_orig, document.sentences)]
+                # TODO: extract the operarions for each sentence in the document
+                operations = [", ".join(document.doc_ops)]
+                sentences = [f'{sent_orig}{self.separator}{sent_clean}{self.separator}{operation}'
+                             for sent_orig, sent_clean, operation in zip(document.sentences_orig,
+                                                                         document.sentences,
+                                                                         operations)]
             else:
                 sentences = document.sentences
             doc_onion = self.start_doc_tag + document.attr_str() + self.start_p_tag + '\n'.join(sentences) + \

--- a/corpus_cleaner/components/i_output_formatter/output_formatter.py
+++ b/corpus_cleaner/components/i_output_formatter/output_formatter.py
@@ -5,7 +5,7 @@ import argparse
 from typing import TextIO
 from typing import Optional
 
-SEPARATOR = " ||| "
+SEPARATOR = "|||"
 
 
 class OutputFormatter(CleanerComponent):

--- a/corpus_cleaner/components/i_output_formatter/output_formatter.py
+++ b/corpus_cleaner/components/i_output_formatter/output_formatter.py
@@ -5,12 +5,15 @@ import argparse
 from typing import TextIO
 from typing import Optional
 
+SEPARATOR = " ||| "
+
 
 class OutputFormatter(CleanerComponent):
     def __init__(self, args: argparse.Namespace, output_path: Optional[str] = None):
         super().__init__(args)
         self.path = output_path if output_path is not None else args.output_path
         self.fd: Union[TextIO, None] = None
+        self.separator = SEPARATOR
 
     @staticmethod
     def add_args(parser: argparse.ArgumentParser):

--- a/corpus_cleaner/components/i_output_formatter/output_formatter.py
+++ b/corpus_cleaner/components/i_output_formatter/output_formatter.py
@@ -5,7 +5,7 @@ import argparse
 from typing import TextIO
 from typing import Optional
 
-SEPARATOR = "|||"
+SEPARATOR = "|"
 
 
 class OutputFormatter(CleanerComponent):

--- a/corpus_cleaner/components/i_output_formatter/sentence_output_formatter.py
+++ b/corpus_cleaner/components/i_output_formatter/sentence_output_formatter.py
@@ -10,7 +10,7 @@ class SentenceOutputFormatter(OutputFormatter):
 
     def _write_document(self, document: Document):
         if len(document.sentences) > 0:
-            sentences = [sentence.replace(' ||| ', '\t') for sentence in document.sentences]
+            sentences = [sentence.replace(f'{self.separator}', '\t') for sentence in document.sentences]
             self.fd.writelines(f'{sentence}\n' for sentence in sentences)
 
     def _end_writing(self):

--- a/corpus_cleaner/components/i_output_formatter/sentence_output_formatter.py
+++ b/corpus_cleaner/components/i_output_formatter/sentence_output_formatter.py
@@ -10,8 +10,8 @@ class SentenceOutputFormatter(OutputFormatter):
 
     def _write_document(self, document: Document):
         if len(document.sentences) > 0:
-            sentences = [sentence.replace(f'{self.separator}', '\t') for sentence in document.sentences]
-            self.fd.writelines(f'{sentence}\n' for sentence in sentences)
+            # sentences = [sentence.replace(f'{self.separator}', '\t') for sentence in document.sentences]
+            self.fd.writelines(f'{sentence}\n' for sentence in document.sentences)
 
     def _end_writing(self):
         self.fd.close()

--- a/corpus_cleaner/components/i_output_formatter/sentence_output_formatter.py
+++ b/corpus_cleaner/components/i_output_formatter/sentence_output_formatter.py
@@ -10,7 +10,8 @@ class SentenceOutputFormatter(OutputFormatter):
 
     def _write_document(self, document: Document):
         if len(document.sentences) > 0:
-            self.fd.writelines(f'{sentence}\n' for sentence in document.sentences)
+            sentences = [sentence.replace(' ||| ', '\t') for sentence in document.sentences]
+            self.fd.writelines(f'{sentence}\n' for sentence in sentences)
 
     def _end_writing(self):
         self.fd.close()

--- a/corpus_cleaner/document.py
+++ b/corpus_cleaner/document.py
@@ -14,7 +14,7 @@ class Document:
                  keywords: Optional[str] = None,
                  heads: Optional[str] = None,
                  language: Optional[str] = None,
-                 operations: Optional[List] = None):
+                 operations: Optional[List] = []):
         self.content = content
         self.content_orig = content
         self.sentences = sentences

--- a/corpus_cleaner/document.py
+++ b/corpus_cleaner/document.py
@@ -14,7 +14,7 @@ class Document:
                  keywords: Optional[str] = None,
                  heads: Optional[str] = None,
                  language: Optional[str] = None,
-                 doc_ops: Optional[List] = None):
+                 operations: Optional[List] = None):
         self.content = content
         self.content_orig = content
         self.sentences = sentences
@@ -26,7 +26,7 @@ class Document:
         self.heads = heads
         self.filename = filename
         self.language = language
-        self.doc_ops = doc_ops
+        self.operations = operations
 
     def attr_str(self) -> str:
         res = []

--- a/corpus_cleaner/document.py
+++ b/corpus_cleaner/document.py
@@ -1,6 +1,7 @@
 from typing import List
 from typing import Optional
 
+
 class Document:
     def __init__(self,
                  content: str,
@@ -12,7 +13,8 @@ class Document:
                  id_: Optional[str] = None,
                  keywords: Optional[str] = None,
                  heads: Optional[str] = None,
-                 language: Optional[str] = None):
+                 language: Optional[str] = None,
+                 operations: Optional[List] = None):
         self.content = content
         self.content_orig = content
         self.sentences = sentences
@@ -24,6 +26,7 @@ class Document:
         self.heads = heads
         self.filename = filename
         self.language = language
+        self.operations = operations
 
     def attr_str(self) -> str:
         res = []
@@ -81,4 +84,3 @@ class Document:
                         heads=get_att('heads'),
                         language=get_att('language')
                         )
-

--- a/corpus_cleaner/document.py
+++ b/corpus_cleaner/document.py
@@ -14,7 +14,7 @@ class Document:
                  keywords: Optional[str] = None,
                  heads: Optional[str] = None,
                  language: Optional[str] = None,
-                 operations: Optional[List] = []):
+                 doc_ops: Optional[List] = None):
         self.content = content
         self.content_orig = content
         self.sentences = sentences
@@ -26,7 +26,7 @@ class Document:
         self.heads = heads
         self.filename = filename
         self.language = language
-        self.operations = operations
+        self.doc_ops = doc_ops
 
     def attr_str(self) -> str:
         res = []

--- a/scripts/balanced_random_sampling.sh
+++ b/scripts/balanced_random_sampling.sh
@@ -113,8 +113,9 @@ for data_dir in ${data_dirs}; do
     fi
 
     cat $(find_files "${data_dir}" "${exclude_names}") | \
-    shuf -n ${number_lines_dir} --random-source=<(get_seeded_random ${seed}) | \
-    sed '/^$/d' | sort | uniq >> ${output_file}
+    sed '/^$/d' | sort | uniq | \
+    shuf -n ${number_lines_dir} --random-source=<(get_seeded_random ${seed}) \
+    >> ${output_file}
 done
 
 sample_lines=$(count_file_lines ${output_file})

--- a/scripts/balanced_random_sampling.sh
+++ b/scripts/balanced_random_sampling.sh
@@ -5,9 +5,7 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 data_dirs=${data_dirs}
 exclude_names=${exclude_names}
 sample_size=${sample_size}
-number_files=${number_files}
 output_file=${output_file}
-check_min_number_lines=${check_min_number_lines:-false}
 debug=${debug:-false}
 seed=${seed:-42}
 
@@ -72,8 +70,8 @@ function count_file_lines(){
 
 # handle arguments values before to perform the sampling
 number_dirs=$(echo ${data_dirs} | wc -w)
-if [[ ${number_files} -lt ${number_dirs} ]]; then
-    echo "Set number_files to a larger number than number_dirs"
+if [[ ${sample_size} -lt ${number_dirs} ]]; then
+    echo "Set sample_size to a larger number than number_dirs"
     exit 0
 fi
 
@@ -102,47 +100,22 @@ fi
 datetime=$(date '+%d-%m-%Y_%H-%M-%S');
 log_file=$(dirname ${output_file})/sample_${datetime}.log
 
-# 1: select the files to extract from
+# 1: select the directories to extract the lines from from
 number_dirs=$(echo ${data_dirs} | wc -w)
-number_files_dir=$(echo "${number_files}/${number_dirs}" | bc )
+number_lines_dir=$(echo "${sample_size}/${number_dirs}" | bc )
 # The pipe command is necessary to find and shuffle in the case of huge number of files
-for data_dir in ${data_dirs}; do
-    echo "Attempting to sample ${number_files_dir} files from directory: ${data_dir} ($(find_files "${data_dir}" "${exclude_names}" | wc -l)) files" | tee -a ${log_file}
-    files_sample+=" "
-    files_sample+=$(find_files "${data_dir}" "${exclude_names}" | \
-        shuf -n ${number_files_dir} --random-source=<(get_seeded_random ${seed}))
-done
-number_files_sample=$(echo ${files_sample} | wc -w)
-total_lines=$(cat ${files_sample} | sed '/^$/d' | wc -l)
-echo -e "Sampled ${number_files_sample} files with total number of lines: ${total_lines}" | tee -a ${log_file}
-
-# 2: Sample number_lines_sample from each files
-number_lines_sample=$(echo "${sample_size}/${number_files_sample}" | bc )
-# Optionally, check if all files have the minimum number of lines
-if [[ ${check_min_number_lines} == "true" ]]; then
-    min_lines_number=$(wc -l ${files_sample} | grep -oP "^\s*[0-9]*" | sort | head -n 1)
-    echo "minimum number of lines: ${min_lines_number}" | tee -a ${log_file}
-    if [[ ${number_lines_sample} -gt ${min_lines_number} ]]; then
-       echo "Number of samples lines per files greater than minimum number of lines available." \
-            "Set sample_size argument to smaller value"
-       exit 0
-    fi
-fi
-
 echo "Balanced sampling..."
 echo -n > ${output_file}
-for file in ${files_sample}; do
-    echo "Attempting to sample ${number_lines_sample} lines from file: ${file} ($(count_file_lines ${file}) lines)" | tee -a ${log_file}
+for data_dir in ${data_dirs}; do
+    echo "Attempting to sample ${number_lines_dir} lines from files in directory: ${data_dir} ($(cat $(find_files "${data_dir}" "${exclude_names}") | wc -l)) files" | tee -a ${log_file}
     if [[ ${debug} == "true" ]]; then
-        echo -e "\nFILE: ${file}" >> ${output_file}
+        echo -e "\nFILE: ${data_dir}" >> ${output_file}
     fi
-    random_lines_sample ${file} ${sample_size} ${number_lines_sample} ${seed} >> ${output_file}
 
+    cat $(find_files "${data_dir}" "${exclude_names}") | \
+    shuf -n ${number_lines_dir} --random-source=<(get_seeded_random ${seed}) | \
+    sed '/^$/d' | sort | uniq >> ${output_file}
 done
 
-if [[ ${debug} != "true" ]]; then
-    echo "Removing duplicates from the final sample" | tee -a ${log_file}
-    sort -u ${output_file} -o ${output_file}
-fi
 sample_lines=$(count_file_lines ${output_file})
 echo "Sampled ${sample_lines} total lines into file: $(realpath ${output_file})" | tee -a ${log_file}

--- a/scripts/balanced_random_sampling.sh
+++ b/scripts/balanced_random_sampling.sh
@@ -2,10 +2,11 @@
 # Small script to perform a balanced random sampling from multiple corpus
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-data_dirs=${data_dirs}
+data_dir=${data_dir}
 exclude_names=${exclude_names}
 sample_size=${sample_size}
-output_file=${output_file}
+output_dir=${output_dir}
+unit=${unit:-files}
 debug=${debug:-false}
 seed=${seed:-42}
 
@@ -31,7 +32,6 @@ function find_files(){
     data_dir=$1
     exclude_names=$2
 
-#    for data_dir in "${data_dirs}"; do
     if [[ ${exclude_names} == "false" ]]; then
         find ${data_dir} -type f
     else
@@ -45,22 +45,13 @@ function find_files(){
 #    done
 }
 
-function random_files_sample(){
-    files=$1
-    number_files=$2
-    seed=$3
-
-    shuf -e ${files} -n ${number_files} --random-source=<(get_seeded_random ${seed})
-}
-
-function random_lines_sample(){
-    file=$1
-    sample_size=$2
-    number_lines=$3
-    seed=$4
-
-    cat ${file} | sed '/^$/d' | sort | uniq | shuf -n  ${number_lines} --random-source=<(get_seeded_random ${seed})
-}
+function random_docs_in_file_sample(){
+     file=$1
+     number=$2
+     seed=$3
+     cat ${file} | sed 's/^$/FAIRSEQLM/g' | tr '\n' ' ' | sed 's/FAIRSEQLM/\n/g' | \
+     shuf -n ${number} --random-source=<(get_seeded_random ${seed})
+ }
 
 function count_file_lines(){
     file=$1
@@ -68,55 +59,78 @@ function count_file_lines(){
 }
 
 
-# handle arguments values before to perform the sampling
-number_dirs=$(echo ${data_dirs} | wc -w)
-if [[ ${sample_size} -lt ${number_dirs} ]]; then
-    echo "Set sample_size to a larger number than number_dirs"
-    exit 0
-fi
-
-if [[ ${sample_size} -lt ${number_files} ]]; then
-    echo "Set sample_size to a larger number than number_files"
-    exit 0
-fi
 
 if [[ -z "${exclude_names}" ]]; then
     exclude_names=false
 fi
 
 if [[ -z "${sample_size}" ]]; then
-    sample_size=1000
+    sample_size=100
 fi
 
-if [[ -z "${output_file}" ]]; then
-    output_file=${SCRIPT_DIR}/sample.${sample_size}.txt
-    if [[ ${debug} == "true" ]]; then
-      output_file=${SCRIPT_DIR}/sample.${sample_size}.debug.txt
-    fi
+if [[ -z "${output_dir}" ]]; then
+    output_dir=${SCRIPT_DIR}
 else
-    mkdir -p $(dirname ${output_file})
+    mkdir -p ${output_dir}
 fi
 
 datetime=$(date '+%d-%m-%Y_%H-%M-%S');
-log_file=$(dirname ${output_file})/sample_${datetime}.log
+log_file=${output_dir}/sample_${datetime}.log
 
 # 1: select the directories to extract the lines from from
-number_dirs=$(echo ${data_dirs} | wc -w)
-number_lines_dir=$(echo "${sample_size}/${number_dirs}" | bc )
+#number_dirs=$(echo ${data_dirs} | wc -w)
+#number_units=$(echo "${sample_size}/${number_dirs}" | bc )
 # The pipe command is necessary to find and shuffle in the case of huge number of files
-echo "Balanced sampling..."
-echo -n > ${output_file}
-for data_dir in ${data_dirs}; do
-    echo "Attempting to sample ${number_lines_dir} lines from files in directory: ${data_dir} ($(cat $(find_files "${data_dir}" "${exclude_names}") | wc -l)) files" | tee -a ${log_file}
+if [[ ${unit} == "lines" ]]; then
+    echo "Attempting to sample ${sample_size} ${unit} from directory: ${data_dir} ($(cat $(find_files "${data_dir}" "${exclude_names}") | wc -l) lines)" | tee -a ${log_file}
     if [[ ${debug} == "true" ]]; then
+        output_file=${output_dir}/lines.${sample_size}.debug.txt
         echo -e "\nFILE: ${data_dir}" >> ${output_file}
+    else
+        output_file=${output_dir}/lines.${sample_size}.txt
     fi
+
+    echo -n > ${output_file}
 
     cat $(find_files "${data_dir}" "${exclude_names}") | \
     sed '/^$/d' | sort | uniq | \
-    shuf -n ${number_lines_dir} --random-source=<(get_seeded_random ${seed}) \
+    shuf -n ${sample_size} --random-source=<(get_seeded_random ${seed}) \
     >> ${output_file}
-done
 
-sample_lines=$(count_file_lines ${output_file})
-echo "Sampled ${sample_lines} total lines into file: $(realpath ${output_file})" | tee -a ${log_file}
+    sample_lines=$(count_file_lines ${output_file})
+    echo "Sampled ${sample_lines} total ${unit} into file: $(realpath ${output_file})" | tee -a ${log_file}
+
+elif [[ ${unit} == "fairseq-lm" ]]; then
+    echo "Attempting to sample ${sample_size} ${unit} lines from directory: ${data_dir} ($(cat $(find_files "${data_dir}" "${exclude_names}") | wc -l) lines)" | tee -a ${log_file}
+    if [[ ${debug} == "true" ]]; then
+        output_file=${output_dir}/lines.${sample_size}.debug.txt
+        echo -e "\nFILE: ${data_dir}" >> ${output_file}
+    else
+        output_file=${output_dir}/lines.${sample_size}.txt
+    fi
+
+    echo -n > ${output_file}
+
+    sample_files=$(find_files "${data_dir}" "${exclude_names}")
+    random_docs_in_file_sample "${sample_files}" ${sample_size} ${seed} \
+    >> ${output_file}
+
+    sample_lines=$(count_file_lines ${output_file})
+    echo "Sampled ${sample_lines} total ${unit} lines into file: $(realpath ${output_file})" | tee -a ${log_file}
+
+elif [[ ${unit} == "files" ]]; then
+    echo "Attempting to sample ${sample_size} ${unit} from directory: ${data_dir} ($(echo $(find_files "${data_dir}" "${exclude_names}") | wc -w) files)" | tee -a ${log_file}
+    files_sample+=" "
+    files_sample+=$(find_files "${data_dir}" "${exclude_names}" | \
+        shuf -n ${sample_size} --random-source=<(get_seeded_random ${seed}))
+
+    for file in ${files_sample}; do
+        echo ${output_dir}/$(basename ${file})
+        cp ${file} ${output_dir}/$(basename ${file})
+    done
+
+    sample_files=$(echo ${files_sample} | wc -w)
+    echo "Sampled ${sample_files} total ${unit} into dir: $(realpath ${output_dir})" | tee -a ${log_file}
+
+fi
+

--- a/scripts/error_sampling.py
+++ b/scripts/error_sampling.py
@@ -2,89 +2,126 @@ import argparse
 import random
 import logging
 import os
-from ordered_set import OrderedSet
+import itertools
+from collections import defaultdict
 
 SCRIPT_DIR = os.path.realpath(__file__)
 
 logging.basicConfig(level=logging.DEBUG)
-
-# 1. Classify sentences in two classes ERROR/NO ERROR
-# 2. Balanced sampling from each class
-SEPARATOR = '|||'
 
 
 class ErrorSampler:
     def __init__(self, sample_size: int, sampling_seed: int):
         self.sample_size = sample_size
         self.sampling_seed = sampling_seed
-        self.sentences_errors = {'error': [], 'no_error': []}
-        self.separator = SEPARATOR
+        self.documents_errors = defaultdict(list)
+        self.separator = ' ||| '
 
     @staticmethod
-    def check_error(sentence_orig, sentence_clean):
-        if not sentence_orig.strip() == sentence_clean.strip():
-            return True
+    def check_error(original, cleaned, input_format):
+        if input_format == 'sentence':
+            if not original.strip() == cleaned.strip():
+                return True
+        # Check if there are at least more than 50% of sentences with error in the document
+        elif input_format == 'fairseq-lm':
+            assert isinstance(original, list) and isinstance(cleaned, list), 'No documents found with fairseq-lm format'
+            percentage_error = round(sum([orig != clean for orig, clean in zip(original, cleaned)]) / len(cleaned), 1)
+            if percentage_error > 0.5:
+                return True
         return False
 
     def parse_file(self, input_file):
         with open(input_file) as fn:
             lines = fn.readlines()
-        assert all(len(line.split(f"{self.separator}")) == 2 for line in lines), \
+        assert all(len(line.split(f"{self.separator}")) == 3 for line in lines if line != '\n'), \
             "Please input a file in a TAB-separated format obtained from the pipeline executed in debug mode"
 
-        return lines
-
-    # 2. Classify sentences in two classes ERROR/NO ERROR
-    def classify(self, input_file):
-        logging.info(f"Classifying sentences in error type from the file: {input_file}")
-        lines = self.parse_file(input_file)
+        original = []
+        cleaned = []
+        operations = []
+        original_doc = []
+        cleaned_doc = []
+        operations_doc = []
         for line in lines:
-            sent_orig, sent_clean = line.split(f"{self.separator}")
-
-            if self.check_error(sent_orig, sent_clean):
-                self.sentences_errors['error'].append(sent_orig)
+            if not line == '\n':
+                original_doc.append(line.split(self.separator)[0])
+                cleaned_doc.append(line.split(self.separator)[1])
+                operations_doc.append(line.split(self.separator)[2])
             else:
-                self.sentences_errors['no_error'].append(sent_orig)
+                original.append(original_doc)
+                cleaned.append(cleaned_doc)
+                operations.append(operations_doc)
+                original_doc = []
+                cleaned_doc = []
+                operations_doc = []
+        return original, cleaned, operations
+
+    # 2. Classify documents in two classes ERROR/NO ERROR
+    def classify(self, input_file, input_format, use_unaligned):
+        logging.info(f"Classifying documents in error type from the file: {input_file}")
+        original, cleaned, operations = self.parse_file(input_file)
+        for orig_doc, clean_doc, ops_doc in zip(original, cleaned, operations):
+            doc = [f'{orig_sent}{self.separator}{clean_sent}{self.separator}{ops_sent}'
+                   for orig_sent, clean_sent, ops_sent in zip(orig_doc, clean_doc, ops_doc)]
+            if self.check_error(orig_doc, clean_doc, input_format):
+                if orig_doc[0].startswith('UNALIGNED:'):
+                    if use_unaligned:
+                        self.documents_errors['unaligned'].append(doc)
+                else:
+                    self.documents_errors['error'].append(doc)
+            else:
+                self.documents_errors['no_error'].append(doc)
 
     def sample(self, output_file):
         # Define a balanced sampling for the ERROR and NO_ERROR classes
-        logging.info("Trying balanced sampling from the 'error' and 'no_error' class")
+        logging.info("Trying balanced sampling from the 'error', 'no_error' and optionally 'unaligned' classes")
         random.seed(self.sampling_seed)  # set fixed random for reproducibility
-        sentences_per_error_type = round(self.sample_size / 2)
-        sample_sentences = []
-        for error, sentences in self.sentences_errors.items():
-            # Check if the number of sampled sentences is greater than the total number of sentences for each
-            # error type before to apply random sampling. If not, select all the sentences of the group type
-            if sentences_per_error_type >= len(sentences):
-                random_sentences = sentences
+        number_error_types = len(self.documents_errors.keys())
+        sentences_per_error_type = round(self.sample_size / number_error_types)
+        sample_documents = []
+        for error, documents in self.documents_errors.items():
+            # Check if the number of sampled documents is greater than the total number of documents for each
+            # error type before to apply random sampling. If not, select all the documents of the group type
+            if sentences_per_error_type >= len(documents):
+                random_documents = documents
             else:
-                random_sentences = list(random.sample(sentences, k=sentences_per_error_type))
-            logging.info(f"Random sampling of {len(random_sentences)} sentences from '{error}' class")
+                random_documents = list(random.sample(documents, k=sentences_per_error_type))
+            logging.info(f"Random sampling of {len(random_documents)} documents from '{error}' class")
 
-            sample_sentences.extend(random_sentences)
+            sample_documents.extend(random_documents)
 
-        sample_sentences = list(OrderedSet(sample_sentences))
+        # remove duplicates
+        # from: https://www.w3resource.com/python-exercises/list/python-data-type-list-exercise-69.php
+        sample_documents.sort()
+        list(sample_documents for sample_documents, _ in itertools.groupby(sample_documents))
 
         with open(output_file, 'w') as of:
-            of.write('\n'.join(sample_sentences))
-        logging.info(f"Collected sample with {len(sample_sentences)} sentences into file {output_file}")
+            for document in sample_documents:
+                for sentence in document:
+                    of.write(sentence)
+                of.write('DOCUMENT\n')
+        logging.info(f"Collected sample with {len(sample_documents)} documents into file {output_file}")
 
-        return sample_sentences
+        return sample_documents
 
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser()
     parser.add_argument('--sample-size', type=int,
-                        help='Number of sentences in the final sample')
+                        help='Number of documents in the final sample')
     parser.add_argument('--sampling-seed', type=int, default=42,
                         help='Seed used for the random sampling')
     parser.add_argument('--input-file', type=str,
-                        help='File containing the sentences that are sampled by error type')
+                        help='File containing the documents that are sampled by error type')
     parser.add_argument('--output-file', type=str,
-                        help='File to write the sampled sentences')
+                        help='File to write the sampled documents')
+    parser.add_argument('--input-format', type=str,
+                        help='Input format that is either fairseq-lm or sentence')
+    parser.add_argument('--use-unaligned', action='store_true',
+                        help='Use documents with unaligned original and cleaned sentences')
 
     args = parser.parse_args()
 
     sampler = ErrorSampler(sample_size=args.sample_size, sampling_seed=args.sampling_seed)
-    sampler.classify(args.input_file)
-    sampler.sample(args.output_file)
+    sampler.classify(args.input_file, args.input_format, args.use_unaligned)
+    sample_documents = sampler.sample(args.output_file)


### PR DESCRIPTION
Implement debug mode that allows registering all the operations (filter/replace) applied during cleaning.

If the `--debug` option is used, the output will contain three fields separated by triple pipe **_|||_**: 

1. original sentence
2. cleaned sentence
3. sequence of operations applied

In the case where is not possible to align the original sentences with the cleaned ones, the first field will start with _UNALIGNED:_ and the entire content of the document will be placed only on the first line. 